### PR TITLE
Opear 12 fix

### DIFF
--- a/src/webrtc-media-provider.js
+++ b/src/webrtc-media-provider.js
@@ -543,7 +543,7 @@ function removeVideoElement(video) {
  */
 var available = function () {
     //return (adapter.browserDetails.browser != "edge") ? navigator.getUserMedia && RTCPeerConnection : false;
-    return navigator.getUserMedia && RTCPeerConnection;
+    return ('getUserMedia' in navigator && 'RTCPeerConnection' in window);
 };
 
 var listDevices = function (labels) {


### PR DESCRIPTION
Opera 12 now correctly falls back to Flash media provider. It crashed before on undefined `RTCPeerConnection` variable.