### PR TITLE
Fix media info collection without a source object

### DIFF
--- a/src/flashphoner-core.js
+++ b/src/flashphoner-core.js
@@ -2897,7 +2897,7 @@ var createSession = function (options) {
         if (!localVideo && mediaProvider.getVideoElement) {
             localVideo = mediaProvider.getVideoElement(display);
         }
-        if (localVideo) {
+        if (localVideo && localVideo.srcObject) {
             localVideo.srcObject.getAudioTracks().forEach((track) => {
                 let device = track.label;
                 if (device === "MediaStreamAudioDestinationNode" && mediaProvider.getAudioSourceDevice) {


### PR DESCRIPTION
We were receiving consistent sentry reports with the following error:
```
null is not an object (evaluating 'localVideo.srcObject.getAudioTracks')
```

The exact reproduction is unclear, though the fix in this PR should be pretty straightforward.