### PR TITLE
Fix error handling in getMobileDevices to reject promises on failure

### DIFF
--- a/src/webrtc-media-provider.js
+++ b/src/webrtc-media-provider.js
@@ -1717,12 +1717,13 @@ const getMobileDevices = async function (kind, deviceConstraints = null) {
                 if (stream.getVideoTracks().length > 0) {
                     deviceId = stream.getVideoTracks()[0].getSettings().deviceId;
                 }
-                stream.getTracks().forEach((track) =>  {
+                stream.getTracks().forEach((track) => {
                     track.stop();
                 });
             }
         } catch (error) {
             logger.error(LOG_PREFIX, "Can't get device access with video constraints " + JSON.stringify(constraints.video) + ", error " + error);
+            throw error;
         }
         return deviceId;
     }
@@ -1752,6 +1753,11 @@ const getMobileDevices = async function (kind, deviceConstraints = null) {
         }
     } catch (error) {
         logger.error(LOG_PREFIX, "Can't get device access with constraints " + JSON.stringify(constraints) + ", error " + error);
+        throw error;
+    }
+
+    if (!list) {
+        throw new Error("No media devices found");
     }
 
     return list;


### PR DESCRIPTION
The getMobileDevices function currently logs errors but does not reject the promise when device access fails (e.g., user denies permission, no cameras/microphones available, or getUserMedia throws). Instead, it resolves with null.

This behavior contradicts getMediaDevices (and standard getUserMedia), which correctly reject the promise on any failure.